### PR TITLE
Update "Muted" event message for Italian translation

### DIFF
--- a/locale/it/LC_MESSAGES/django.po
+++ b/locale/it/LC_MESSAGES/django.po
@@ -73,7 +73,7 @@ msgstr "espulso permanentemente dal gruppo"
 
 #: telegrambot/logging.py:16
 msgid "muted in the group"
-msgstr "mutato nel gruppo"
+msgstr "silenziato nel gruppo"
 
 #: telegrambot/logging.py:17
 msgid "unbanned from the group"


### PR DESCRIPTION
This PR proposes an alternate translation for a string in the Italian locale, avoiding the usage of anglicisms derived from internet slang.

> **T:** «I am the Prophet of Truth! The voice of the Covenant!»
> **A:** «And so, you must be _silenced_.»